### PR TITLE
fix editor scroll bar on first load

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -49,6 +49,9 @@ class Editor extends React.Component<EditorProps> {
 
     componentDidMount(): void {
         window.addEventListener('storage', this.onStorage);
+        // scroll bar is broken unless we do this when there is an ancestor
+        // that resizes things during load.
+        setTimeout(() => this.editorRef.current?.editor.resize(), 0);
     }
 
     componentWillUnmount(): void {


### PR DESCRIPTION
It seems that some container of the Editor component is breaking the resize calculation when the page firsts loads. So we have to be bit hacky and defer the call the resize until after all components have been rendered.