### PR TITLE
Rework web assembly inclusion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 /node_modules
 /.pnp
 .pnp.js
-*.wasm
 
 # testing
 /coverage

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "dependencies": {
         "@blueprintjs/core": "^3.28.1",
         "@pybricks/firmware": "2.4.0",
-        "@pybricks/mpy-cross-v5": "^1.0.0",
+        "@pybricks/mpy-cross-v5": "^1.1.0",
         "@shopify/react-i18n": "^5.0.0",
         "@testing-library/jest-dom": "^5.8.0",
         "@testing-library/react": "^10.2.1",
@@ -40,7 +40,7 @@
         "zen-push": "^0.2.1"
     },
     "scripts": {
-        "prepare": "mkdir -p public/static/js && cp node_modules/@pybricks/mpy-cross-v5/build/mpy-cross.wasm public/static/js/",
+        "prepare": "mkdir -p public/static/js && ncp node_modules/@pybricks/mpy-cross-v5/build/mpy-cross.wasm src/sagas/mpy-cross.emcwasm",
         "start": "react-scripts start",
         "build": "react-scripts build",
         "test": "react-scripts test --env=./test/env.js",
@@ -73,6 +73,7 @@
         "eslint-plugin-prettier": "^3.1.2",
         "eslint-plugin-react": "^7.20.0",
         "jest-mock-extended": "^1.0.9",
+        "ncp": "^2.0.0",
         "prettier": "^2.0.4"
     }
 }

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -5,6 +5,11 @@ declare module '*.json' {
     export default src;
 }
 
+declare module '*.emcwasm' {
+    const src: string;
+    export default src;
+}
+
 declare module '*.zip' {
     const src: string;
     export default src;

--- a/src/sagas/.gitignore
+++ b/src/sagas/.gitignore
@@ -1,0 +1,1 @@
+*.emcwasm

--- a/src/sagas/mpy.ts
+++ b/src/sagas/mpy.ts
@@ -9,6 +9,7 @@ import {
     didCompile,
     didFailToCompile,
 } from '../actions/mpy';
+import wasm from './mpy-cross.emcwasm';
 
 /**
  * Compiles a script to .mpy and dispatches either didCompile on success or
@@ -17,7 +18,13 @@ import {
  */
 function* compile(action: MpyCompileAction): Generator {
     const result = (yield call(() =>
-        mpyCrossCompile('main.py', action.script, action.options),
+        mpyCrossCompile(
+            'main.py',
+            action.script,
+            action.options,
+            // HACK: testing user agent for jsdom is needed only for getting unit tests to work
+            navigator.userAgent.includes('jsdom') ? undefined : wasm,
+        ),
     )) as CompileResult;
     if (result.status === 0 && result.mpy) {
         yield put(didCompile(result.mpy));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1360,10 +1360,10 @@
   resolved "https://npm.pkg.github.com/download/@pybricks/firmware/2.4.0/8cc8e7f4e51d1447b563cf84de714d7d66a60523bfc2c9e882b748fe9760ff1e#03a1e049acac737c0bb69a673061db1ba27fd257"
   integrity sha512-HLEEAaCNeAAw+ucKjUZudIWklbp2Mv5DGFDBavOmp2tdXRSYch9P2MsyuYj9J+t+lW6PvdviteXtCQ+kqLVDKg==
 
-"@pybricks/mpy-cross-v5@^1.0.0":
-  version "1.0.0"
-  resolved "https://npm.pkg.github.com/download/@pybricks/mpy-cross-v5/1.0.0/f6f06c2be87cdd5785dfa13c51b8ea5b33094028592ff8a37385c3b977e30ce2#06e912bec5c789b98b9dfb6701697c0d66cb69dc"
-  integrity sha512-2aJWXeC/nd0UqowZhcdA7vFfjOM+ikMsSa80Cd41RzYUOqx9CuL9vdBlY4nZAgzyCt+8HuX5dGJOt1CQ0IPwSQ==
+"@pybricks/mpy-cross-v5@^1.1.0":
+  version "1.1.0"
+  resolved "https://npm.pkg.github.com/download/@pybricks/mpy-cross-v5/1.1.0/01b9fe3498310264b7b826d7bb596ef593b3b92de93503933ca14fb9efb5160e#5fe7eb7f5b8d0f783c16eab92d4e1b96bcfba0cb"
+  integrity sha512-rARDzR1/PfzGLJVnyOeDRSsWmdHOPSQed0IeRG8T3YpFSGywR8z/UoSq1jurVETZvSEIOj1P4nmd0ZAPa3+bMA==
 
 "@redux-saga/core@^1.1.3":
   version "1.1.3"
@@ -7686,6 +7686,11 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+
+ncp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
+  integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
 
 negotiator@0.6.2:
   version "0.6.2"


### PR DESCRIPTION
This moves the .wasm file out of the static/js/ folder and into the
source tree. This way we can import it and webpack will pick it up
and version the file with a hash.

This fixes possibly running with an out of date file from the browser
cache and also fixes running offline.

The file extension had to be changed because there is a default rule in
webpack that matches the .wasm extension and causes the following error:

    Failed to compile.

    ./src/sagas/mpy-cross.wasm
    Module parse failed: magic header not detected
    File was processed with these loaders:
    * ./node_modules/file-loader/dist/cjs.js
    You may need an additional loader to handle the result of these loaders.
    Error: magic header not detected

The webpack configuration cannot be modified without ejecting
create-react-app or using something like react-app-rewired, which we
would like to avoid.

Also using ncp to copy file now which fixes building on Windows.