### PR TITLE
remove stickiness of toolbar to avoid breaking the layout

### DIFF
--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -18,7 +18,6 @@ class Toolbar extends React.Component {
         return (
             <Navbar
                 onContextMenu={(e): void => e.preventDefault()}
-                fixedToTop={true}
                 className="no-box-shadow"
             >
                 <Navbar.Group>

--- a/src/index.scss
+++ b/src/index.scss
@@ -28,8 +28,6 @@ $status-bar-height: 3vh;
 body {
     // no scrolling of the page
     overflow: hidden;
-    // See https://blueprintjs.com/docs/#core/components/navbar
-    padding-top: $pt-navbar-height;
 }
 
 // Utility classes


### PR DESCRIPTION
Hi!

I was able to reproduce the issue described in #161 as follow:

* Open https://code.pybricks.com/
* Look for a link with a URI fragment in the documentation (e.g. https://docs.pybricks.com/en/latest/parameters.html#pybricks.parameters.Port)
* Click it.

=> Layout breaks as described in the issue.

After some googling I found that this behaviour comes from the browser itself.
The browser seems to force the parent frame to scroll to the position of the referenced URI fragment as well.
But as the toolbar is fixed, the rest of the content is scrolled under it.
Re-rendering after the link click fixes the layout (at least if done manually by removing and adding a CSS class in the dev tools).

I could not find a nice solution to force this re-rendering somehow. 
After looking deeper how the layout is built, I was wondering why the toolbar is fixed to the top at all?
The editor always spans over the full width and height of the current window and all elements are placed nicely inside this view and handle scrolling on their own.

After removing the `fixedToTop` property of the toolbar (and the padding) everything looks (at least in my browser) the same and seems to work as before.
But maybe I'm missing some browser-specific quirks here?
Would be super awesome if someone can verify that this really fixes the issue! 😄 