### PR TITLE
fix extra pixels under icons in buttons

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -48,6 +48,10 @@ body {
     user-select: none;
 }
 
+.#{$ns}-button-text > img {
+    display: block;
+}
+
 .#{$ns}-form-group > .#{$ns}-label {
     font-weight: bolder;
 }


### PR DESCRIPTION
Since the img is in a span, it was treated as text and added 4 pixelson the bottom for the descender height.

By using `display: block;` it won't be treated as text.

Fixes pybricks/pybricks-code#268