### PR TITLE
Add Python 2 dependency

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 nodejs 12.18.3
+python 2.7.18

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,13 @@ We are using [Yarn][yarn] 1.x for package management.
 
 [yarn]: https://classic.yarnpkg.com/
 
+### Python
+
+One of the node depedencies needs Python 2 in order to build!
+
+If you see [this error](https://github.com/palantir/blueprint/issues/4273),
+that is what is going on.
+
 ### Git Version Control
 
 You will need [Git][git] to get the source code from GitHub. (Say that 3 times fast!)


### PR DESCRIPTION
A depedency of blueprintsjs needs Python 2 to build.

https://github.com/palantir/blueprint/issues/4273