### PR TITLE
Fix lint errors on Windows.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = {
         'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
         'sort-imports': ['error', { ignoreDeclarationSort: true }],
         'import/order': ['error', { alphabetize: { order: 'asc' } }],
+        'prettier/prettier': ['error', { endOfLine: 'auto' }],
     },
     settings: {
         react: { version: 'detect' },


### PR DESCRIPTION
On Windows, I'm getting the following errors for all lines and many (or all?) files:

![image](https://user-images.githubusercontent.com/12326241/118448940-e24d7500-b6f2-11eb-8d4a-784d67aa501a.png)

Fix comes from https://stackoverflow.com/questions/53516594/why-do-i-keep-getting-delete-cr-prettier-prettier

