### PR TITLE
Bump @pybricks/ide-docs from 1.3.2 to 1.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "@blueprintjs/core": "^3.41.0",
         "@craco/craco": "^6.1.1",
         "@pybricks/firmware": "4.11.0",
-        "@pybricks/ide-docs": "1.3.2",
+        "@pybricks/ide-docs": "1.3.3",
         "@pybricks/mpy-cross-v5": "^2.0.0",
         "@shopify/react-i18n": "^5.3.0",
         "@testing-library/dom": "^7.30.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1543,10 +1543,10 @@
   dependencies:
     jszip "^3.5.0"
 
-"@pybricks/ide-docs@1.3.2":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@pybricks/ide-docs/-/ide-docs-1.3.2.tgz#7c19e67fd06692e419f9338e6e94cad1b20f8d39"
-  integrity sha512-ZKJUQZIL4GPSGjEK3lShisRlupX1XWu5H89N8+QfMqwU6xdDR8oz5/zhxiPSlHjGsrCRNilzmbHsUfIVXwkGFA==
+"@pybricks/ide-docs@1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@pybricks/ide-docs/-/ide-docs-1.3.3.tgz#827f8b8bb3ce930fb1af4accc7e2ededb19dcd0b"
+  integrity sha512-Qf+xF47QZ8mEt0Au8zZ4gXXImy+hqubUBNIRz2Yigkrz8lDb8K2vHGNsy65iadwf/B4S2ayzuEHhAYsftSmMYw==
 
 "@pybricks/mpy-cross-v5@^2.0.0":
   version "2.0.0"


### PR DESCRIPTION
This brings in the updated code snippet style.

Also includes a new example for use in a video tutorial.