### PR TITLE
bump copyright year to 2022

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2021 The Pybricks Authors
+Copyright (c) 2020-2022 The Pybricks Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Assume the copyright text is copied automatically over all modules that need it.