### PR TITLE
fix error message when flashing firmware

### DIFF
--- a/src/firmware/sagas.ts
+++ b/src/firmware/sagas.ts
@@ -196,7 +196,7 @@ function* loadFirmware(
         program = yield* call(() => reader.readMainPy());
     }
 
-    if (metadata['mpy-abi-version'] !== 5) {
+    if (![5, 6].includes(metadata['mpy-abi-version'])) {
         yield* put(
             didFailToFinish(
                 FailToFinishReasonType.BadMetadata,


### PR DESCRIPTION
We missed a check for MPY ABI v6 compatibility.