### PR TITLE
fix explorer import silently ignored when invalid file name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@
 - Fixed run button enabled when no file open ([support#691]).
 - Fixed flash firmware dialog not showing when settings not open ([support#694]).
 - Fixed errors not handled while flashing firmware via USB ([pybricks-code#1011]).
+- Fixed imports with invalid file name silently ignored ([support#717]).
 
 [pybricks-code#1011]: https://github.com/pybricks/pybricks-code/issues/1011
 [support#691]: https://github.com/pybricks/support/issues/691
 [support#694]: https://github.com/pybricks/support/issues/694
+[support#717]: https://github.com/pybricks/support/issues/717
 
 ## [2.0.0-beta.5] - 2022-07-28
 

--- a/src/explorer/Explorer.tsx
+++ b/src/explorer/Explorer.tsx
@@ -45,6 +45,7 @@ import DuplicateFileDialog from './duplicateFileDialog/DuplicateFileDialog';
 import { useI18n } from './i18n';
 import NewFileWizard from './newFileWizard/NewFileWizard';
 import RenameFileDialog from './renameFileDialog/RenameFileDialog';
+import RenameImportDialog from './renameImportDialog/RenameImportDialog';
 
 type ActionButtonProps = {
     /** The DOM id for this instance. */
@@ -417,6 +418,7 @@ const Explorer: React.VFC = () => {
             <FileTree />
             <NewFileWizard />
             <RenameFileDialog />
+            <RenameImportDialog />
             <DuplicateFileDialog />
             <DeleteFileAlert />
         </div>

--- a/src/explorer/reducers.ts
+++ b/src/explorer/reducers.ts
@@ -7,10 +7,12 @@ import deleteFileAlert from './deleteFileAlert/reducers';
 import duplicateFileDialog from './duplicateFileDialog/reducers';
 import newFileWizard from './newFileWizard/reducers';
 import renameFileDialog from './renameFileDialog/reducers';
+import renameImportDialog from './renameImportDialog/reducers';
 
 export default combineReducers({
     duplicateFileDialog,
     deleteFileAlert,
     newFileWizard,
     renameFileDialog,
+    renameImportDialog,
 });

--- a/src/explorer/renameImportDialog/RenameImportDialog.test.tsx
+++ b/src/explorer/renameImportDialog/RenameImportDialog.test.tsx
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2022 The Pybricks Authors
+
+import { waitFor } from '@testing-library/dom';
+import React from 'react';
+import { testRender } from '../../../test';
+import RenameImportDialog from './RenameImportDialog';
+import { renameImportDialogDidAccept, renameImportDialogDidCancel } from './actions';
+
+describe('rename button', () => {
+    it('should accept the dialog Rename is clicked', async () => {
+        const [user, dialog, dispatch] = testRender(<RenameImportDialog />, {
+            explorer: { renameImportDialog: { isOpen: true, fileName: 'old.file' } },
+        });
+
+        const button = dialog.getByRole('button', { name: 'Rename' });
+
+        // have to type a new file name before Rename button is enabled
+        const input = dialog.getByLabelText('File name');
+        await waitFor(() => expect(input).toHaveFocus());
+        await user.type(input, 'new', { skipClick: true });
+        await waitFor(() => expect(button).not.toBeDisabled());
+
+        await user.click(button);
+        expect(dispatch).toHaveBeenCalledWith(
+            renameImportDialogDidAccept('old.file', 'new.file'),
+        );
+    });
+
+    it('should accept the dialog when enter is pressed in the text input', async () => {
+        const [user, dialog, dispatch] = testRender(<RenameImportDialog />, {
+            explorer: { renameImportDialog: { isOpen: true, fileName: 'old.file' } },
+        });
+
+        // have to type a new file name before Rename button is enabled
+        const input = dialog.getByLabelText('File name');
+        await waitFor(() => expect(input).toHaveFocus());
+        await user.type(input, 'new{Enter}', { skipClick: true });
+
+        expect(dispatch).toHaveBeenCalledWith(
+            renameImportDialogDidAccept('old.file', 'new.file'),
+        );
+    });
+
+    it('should cancel when close button is clicked', async () => {
+        const [user, dialog, dispatch] = testRender(<RenameImportDialog />, {
+            explorer: { renameImportDialog: { isOpen: true } },
+        });
+
+        const button = dialog.getByRole('button', { name: 'Close' });
+
+        await waitFor(() => expect(button).toBeVisible());
+
+        await user.click(button);
+        expect(dispatch).toHaveBeenCalledWith(renameImportDialogDidCancel());
+    });
+
+    it('should cancel when skip button is clicked', async () => {
+        const [user, dialog, dispatch] = testRender(<RenameImportDialog />, {
+            explorer: { renameImportDialog: { isOpen: true } },
+        });
+
+        const button = dialog.getByRole('button', { name: 'Skip importing this file' });
+
+        await waitFor(() => expect(button).toBeVisible());
+
+        await user.click(button);
+        expect(dispatch).toHaveBeenCalledWith(renameImportDialogDidCancel());
+    });
+});

--- a/src/explorer/renameImportDialog/RenameImportDialog.tsx
+++ b/src/explorer/renameImportDialog/RenameImportDialog.tsx
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2022 The Pybricks Authors
+
+import { Button, Classes, Dialog } from '@blueprintjs/core';
+import React, { useCallback, useRef, useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { appName } from '../../app/constants';
+import { useFileStorageMetadata } from '../../fileStorage/hooks';
+import {
+    FileNameValidationResult,
+    validateFileName,
+} from '../../pybricksMicropython/lib';
+import { useSelector } from '../../reducers';
+import FileNameFormGroup from '../fileNameFormGroup/FileNameFormGroup';
+import { renameImportDialogDidAccept, renameImportDialogDidCancel } from './actions';
+import { useI18n } from './i18n';
+
+const RenameImportDialog: React.VFC = () => {
+    const i18n = useI18n();
+    const dispatch = useDispatch();
+    const isOpen = useSelector((s) => s.explorer.renameImportDialog.isOpen);
+    const oldName = useSelector((s) => s.explorer.renameImportDialog.fileName);
+
+    const [baseName, extension] = oldName.split(/(\.\w+)$/);
+
+    const [newName, setNewName] = useState(baseName);
+    const files = useFileStorageMetadata() ?? [];
+    const result = validateFileName(
+        newName,
+        extension,
+        files.map((f) => f.path),
+    );
+
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    const handleSubmit = useCallback<React.FormEventHandler>(
+        (e) => {
+            e.preventDefault();
+            dispatch(renameImportDialogDidAccept(oldName, `${newName}${extension}`));
+        },
+        [dispatch, oldName, newName, extension],
+    );
+
+    const handleClose = useCallback(() => {
+        dispatch(renameImportDialogDidCancel());
+    }, [dispatch]);
+
+    return (
+        <Dialog
+            title={i18n.translate('title')}
+            isOpen={isOpen}
+            onOpening={() => setNewName(baseName)}
+            onOpened={() => {
+                inputRef.current?.select();
+                inputRef.current?.focus();
+            }}
+            onClose={handleClose}
+        >
+            <form onSubmit={handleSubmit}>
+                <div className={Classes.DIALOG_BODY}>
+                    <p>{i18n.translate('message', { fileName: oldName, appName })}</p>
+                    <FileNameFormGroup
+                        fileName={newName}
+                        fileExtension={extension}
+                        validationResult={result}
+                        inputRef={inputRef}
+                        onChange={setNewName}
+                    />
+                </div>
+                <div className={Classes.DIALOG_FOOTER}>
+                    <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+                        <Button intent="none" onClick={handleClose}>
+                            {i18n.translate('action.skip')}
+                        </Button>
+                        <Button
+                            intent="primary"
+                            disabled={result !== FileNameValidationResult.IsOk}
+                            type="submit"
+                        >
+                            {i18n.translate('action.rename')}
+                        </Button>
+                    </div>
+                </div>
+            </form>
+        </Dialog>
+    );
+};
+
+export default RenameImportDialog;

--- a/src/explorer/renameImportDialog/actions.ts
+++ b/src/explorer/renameImportDialog/actions.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2022 The Pybricks Authors
+
+import { createAction } from '../../actions';
+
+/**
+ * Action that requests to show the rename file dialog.
+ * @param oldName The old file name.
+ */
+export const renameImportDialogShow = createAction((oldName: string) => ({
+    type: 'explorer.renameImportDialog.action.show',
+    oldName,
+}));
+
+/**
+ * Action that indicates the rename file dialog was accepted.
+ * @param oldName The old file name.
+ * @param newName The new file name.
+ */
+export const renameImportDialogDidAccept = createAction(
+    (oldName: string, newName: string) => ({
+        type: 'explorer.renameImportDialog.action.didAccept',
+        oldName,
+        newName,
+    }),
+);
+
+/**
+ * Action that indicates the rename file dialog was canceled.
+ */
+export const renameImportDialogDidCancel = createAction(() => ({
+    type: 'explorer.renameImportDialog.action.didCancel',
+}));

--- a/src/explorer/renameImportDialog/i18n.ts
+++ b/src/explorer/renameImportDialog/i18n.ts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2022 The Pybricks Authors
+
+import { useI18n as useShopifyI18n } from '@shopify/react-i18n';
+import type { TypedI18n } from '../../i18n';
+import type translations from './translations/en.json';
+
+export function useI18n(): TypedI18n<typeof translations> {
+    // istanbul ignore next: babel-loader rewrites this line
+    const [i18n] = useShopifyI18n();
+    return i18n;
+}

--- a/src/explorer/renameImportDialog/reducers.ts
+++ b/src/explorer/renameImportDialog/reducers.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2022 The Pybricks Authors
+
+import { Reducer, combineReducers } from 'redux';
+import {
+    renameImportDialogDidAccept,
+    renameImportDialogDidCancel,
+    renameImportDialogShow,
+} from './actions';
+
+/** Controls the rename file dialog isOpen state. */
+const isOpen: Reducer<boolean> = (state = false, action) => {
+    if (renameImportDialogShow.matches(action)) {
+        return true;
+    }
+
+    if (
+        renameImportDialogDidAccept.matches(action) ||
+        renameImportDialogDidCancel.matches(action)
+    ) {
+        return false;
+    }
+
+    return state;
+};
+
+/** Controls the rename file dialog file name input box text. */
+const fileName: Reducer<string> = (state = '', action) => {
+    if (renameImportDialogShow.matches(action)) {
+        return action.oldName;
+    }
+
+    return state;
+};
+
+export default combineReducers({ isOpen, fileName });

--- a/src/explorer/renameImportDialog/translations/en.json
+++ b/src/explorer/renameImportDialog/translations/en.json
@@ -1,0 +1,8 @@
+{
+    "title": "Rename imported file",
+    "message": "The name of the imported file '{fileName}' is not allowed in {appName}. Please change the name below.",
+    "action": {
+        "skip": "Skip importing this file",
+        "rename": "Rename"
+    }
+}


### PR DESCRIPTION
This finishes a TODO to handle allowing the user to rename a file with an invalid file name when import files from the file system.

Fixes: https://github.com/pybricks/support/issues/717