### PR TITLE
Revert "yarn: update react-complex-tree to v2.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
         "react": "^16.13.1",
         "react-app-polyfill": "^3.0.0",
         "react-aria": "^3.21.0",
-        "react-complex-tree": "^2.0.0",
+        "react-complex-tree": "^1.1.11",
         "react-dev-utils": "^12.0.1",
         "react-dom": "^16.13.1",
         "react-dropzone": "^14.2.3",

--- a/src/explorer/Explorer.tsx
+++ b/src/explorer/Explorer.tsx
@@ -370,7 +370,7 @@ const FileTree: React.VoidFunctionComponent = () => {
                     [rootItemIndex]: {
                         index: rootItemIndex,
                         data: { fileName: '/' },
-                        isFolder: true,
+                        hasChildren: true,
                         children: [...files].map((f) => f.uuid),
                     },
                 } as Record<TreeItemIndex, FileTreeItem>,

--- a/src/utils/tree-renderer.tsx
+++ b/src/utils/tree-renderer.tsx
@@ -99,7 +99,7 @@ export const renderers: Omit<
                         )}
                         {...props.context.itemContainerWithoutChildrenProps}
                     >
-                        {props.item.isFolder ? (
+                        {props.item.hasChildren ? (
                             props.arrow
                         ) : (
                             <span className={Classes.TREE_NODE_CARET_NONE} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2502,7 +2502,7 @@ __metadata:
     react: ^16.13.1
     react-app-polyfill: ^3.0.0
     react-aria: ^3.21.0
-    react-complex-tree: ^2.0.0
+    react-complex-tree: ^1.1.11
     react-dev-utils: ^12.0.1
     react-dom: ^16.13.1
     react-dropzone: ^14.2.3
@@ -12998,12 +12998,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-complex-tree@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "react-complex-tree@npm:2.0.0"
-  peerDependencies:
-    react: ">=18.0.0"
-  checksum: e835f2b44ea2a35b17eb6bc08076dc083265b36e1391253b8ce93904e363089f053addda51f68acee98ff075b4128644c7c274df13b1b4cfcfa454bbb8814769
+"react-complex-tree@npm:^1.1.11":
+  version: 1.1.11
+  resolution: "react-complex-tree@npm:1.1.11"
+  checksum: 80c332fb7c652d51705b740189318fb142f225e3836968d051140e9c7a77dce24953c4fab300bca8c571b4a570537ca112bc25a3255c917dd5e14ec1143eddb7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This reverts commit f0434b50edac11dc5935e49b3baf807cc3922d39.

This requires react >= v18