### PR TITLE
public/manifest: change display to "standalone"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 ### Added
 - Added audio and visual feedback when typing into terminal while user program is not running.
 
+### Changed
+- Changed app display from "fullscreen" to "standalone" ([support#867]).
+
+[support#867]: https://github.com/pybricks/support/issues/867
+
 ## [2.0.1] - 2022-12-21
 
 ### Fixed

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -21,7 +21,7 @@
         }
     ],
     "start_url": ".",
-    "display": "fullscreen",
+    "display": "standalone",
     "theme_color": "#000000",
     "background_color": "#ffffff"
 }


### PR DESCRIPTION
"fullscreen" is for immersive apps like games (and is only available on Android currently which is why we didn't notice the app going fullscreen on desktop).

Fixes: https://github.com/pybricks/support/issues/867