### PR TITLE
editor: show error message on fail to activate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ## [Unreleased]
 
+### Fixed
+- Show error message when go to syntax error fails to activate file ([support#924]).
+
+[support#924]: https://github.com/pybricks/support/issues/924
+
 ## [2.1.0] - 2023-01-06
 
 ### Changed


### PR DESCRIPTION
When gotoError fails to activate a file, we need to show an error message, otherwise it just appears to the user that the button is broken.

Fixes: https://github.com/pybricks/support/issues/924