### PR TITLE
Update documentation to specify Node 18.x

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ These are the required software tools you need to install on your computer.
 
 ### Node.js
 
-We are using [Node.js][node] v12.x. We recommend using a tool such as [asdf][asdf]
+We are using [Node.js][node] v18.x. We recommend using a tool such as [asdf][asdf]
 or [nvm][nvm] if you need to install more than one version of Node.js.
 
 [node]: https://nodejs.org/en/


### PR DESCRIPTION
Update the documentation to list Node 18.x as the used Node version, rather than 12.x