### PR TITLE
editor: don't paste on middle click to close tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 ### Added
 - Added warning message when hub has newer Pybricks Profile version than supported version.
 
+### Fixed
+- Fix pasting selection when middle click to close file on Linux ([support#1046]).
+
+[support#1046]: https://github.com/pybricks/support/issues/1046
+
 ## [2.2.0-beta.3] - 2023-04-24
 
 ### Added

--- a/src/editor/Editor.tsx
+++ b/src/editor/Editor.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2020-2022 The Pybricks Authors
+// Copyright (c) 2020-2023 The Pybricks Authors
 
 import './editor.scss';
 import {
@@ -263,7 +263,8 @@ const EditorTabs: React.VoidFunctionComponent<EditorTabsProps> = ({ onChange }) 
     );
 
     // close tab when middle-clicked
-    const handleMouseDown = useCallback(
+    // NB: this has to be on mouse up event to prevent middle-click paste on Linux
+    const handleMouseUp = useCallback(
         (e: React.MouseEvent, uuid: UUID) => {
             if (e.button === 1) {
                 dispatch(editorCloseFile(uuid));
@@ -310,7 +311,7 @@ const EditorTabs: React.VoidFunctionComponent<EditorTabsProps> = ({ onChange }) 
                     key={uuid}
                     id={uuid}
                     onKeyDown={(e) => handleKeyDown(e, uuid)}
-                    onMouseDown={(e) => handleMouseDown(e, uuid)}
+                    onMouseUp={(e) => handleMouseUp(e, uuid)}
                 >
                     <TabLabel
                         id={`${labelId}.${uuid}`}
@@ -472,6 +473,7 @@ const Editor: React.VFC = () => {
             rulers: [80],
             lineNumbersMinChars: 4,
             wordBasedSuggestions: false,
+            selectionClipboard: false, // don't copy selection on Linux
         });
 
         monacoEditor.focus();


### PR DESCRIPTION
To avoid the Linux feature of pasting on middle click, we need to consume the mouse up event in the browser on middle click instead of mouse down.

This also sets the `selectionClipboard` editor option to false which should disable the feature altogether in the monaco editor but the setting seems to be broken in the browser[1].

[1]: https://github.com/microsoft/vscode/issues/181050

Fixes: https://github.com/pybricks/support/issues/1046