### PR TITLE
ble-pybricks-service/protocol: add UserProgramMultiMpy6Native6p1

### DIFF
--- a/src/ble-pybricks-service/protocol.ts
+++ b/src/ble-pybricks-service/protocol.ts
@@ -269,11 +269,19 @@ export enum HubCapabilityFlag {
      */
     HasRepl = 1 << 0,
     /**
-     * Hub supports {@link FileFormat.MultiMpy6}
+     * Hub supports {@link FileFormat.MultiMpy6} (bytecode only, no native modules).
      *
      * @since Pybricks Profile v1.2.0
      */
     UserProgramMultiMpy6 = 1 << 1,
+
+    /**
+     * Hub supports {@link FileFormat.MultiMpy6} that include native modules
+     * with MPY ABI v6.1.
+     *
+     * @since Pybricks Profile v1.3.0
+     */
+    UserProgramMultiMpy6Native6p1 = 1 << 2,
 }
 
 /** Supported user program file formats. */


### PR DESCRIPTION
This adds a new flag from Pybricks Profile v1.3.0 for documentation purposes. We currently don't support native modules in Pybricks Code so we aren't using this for now.