### PR TITLE
explorer: active file after duplicating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@
 
 ### Fixed
 - Fixed importing/replacing file when file is open in editor ([support#975]).
+- Fixed file not opened when duplicating ([support#1084]).
 
 [support#975]: https://github.com/pybricks/support/issues/975
+[support#1084]: https://github.com/pybricks/support/issues/1084
 
 
 ## [2.2.0-beta.4] - 2023-05-16

--- a/src/explorer/sagas.test.ts
+++ b/src/explorer/sagas.test.ts
@@ -777,7 +777,9 @@ describe('handleExplorerDuplicateFile', () => {
         });
 
         it('should dispatch action on fileStorageDuplicateFile success', async () => {
-            saga.put(fileStorageDidCopyFile('old.file'));
+            saga.put(fileStorageDidCopyFile('old.file', uuid(1)));
+
+            await expect(saga.take()).resolves.toEqual(editorActivateFile(uuid(1)));
 
             await expect(saga.take()).resolves.toEqual(
                 explorerDidDuplicateFile('old.file'),

--- a/src/explorer/sagas.ts
+++ b/src/explorer/sagas.ts
@@ -439,7 +439,7 @@ function* handleExplorerDuplicateFile(
 
         yield* put(fileStorageCopyFile(action.fileName, didAccept.newName));
 
-        const { didFailToCopy } = yield* race({
+        const { didCopy, didFailToCopy } = yield* race({
             didCopy: take(
                 fileStorageDidCopyFile.when((a) => a.path === action.fileName),
             ),
@@ -451,6 +451,10 @@ function* handleExplorerDuplicateFile(
         if (didFailToCopy) {
             throw didFailToCopy.error;
         }
+
+        defined(didCopy);
+
+        yield* put(editorActivateFile(didCopy.newUuid));
 
         yield* put(explorerDidDuplicateFile(action.fileName));
     } catch (err) {

--- a/src/fileStorage/actions.ts
+++ b/src/fileStorage/actions.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2022 The Pybricks Authors
+// Copyright (c) 2022-2023 The Pybricks Authors
 
 import type * as monaco from 'monaco-editor';
 import { createAction } from '../actions';
@@ -236,11 +236,13 @@ export const fileStorageCopyFile = createAction((path: string, newPath: string) 
 
 /**
  * Indicates that {@link fileStorageCopyFile} succeeded.
- * @param path: The file path.
+ * @param path: The original file path.
+ * @param newUuid: The UUID of the new copy.
  */
-export const fileStorageDidCopyFile = createAction((path: string) => ({
+export const fileStorageDidCopyFile = createAction((path: string, newUuid: UUID) => ({
     type: 'fileStorage.action.didCopyFile',
     path,
+    newUuid,
 }));
 
 /**

--- a/src/fileStorage/sagas.test.ts
+++ b/src/fileStorage/sagas.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2022 The Pybricks Authors
+// Copyright (c) 2022-2023 The Pybricks Authors
 
 import 'fake-indexeddb/auto';
 import Dexie from 'dexie';
@@ -590,7 +590,9 @@ describe('copyFile', () => {
     it('should copy file', async () => {
         saga.put(fileStorageCopyFile('test.file', 'new.file'));
 
-        await expect(saga.take()).resolves.toEqual(fileStorageDidCopyFile('test.file'));
+        await expect(saga.take()).resolves.toEqual(
+            fileStorageDidCopyFile('test.file', uuid(1)),
+        );
     });
 
     afterEach(async () => {

--- a/src/fileStorage/sagas.ts
+++ b/src/fileStorage/sagas.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2022 The Pybricks Authors
+// Copyright (c) 2022-2023 The Pybricks Authors
 
 import Dexie from 'dexie';
 import {
@@ -375,6 +375,8 @@ function* handleCopyFile(
     action: ReturnType<typeof fileStorageCopyFile>,
 ): Generator {
     try {
+        let uuid: UUID | undefined = undefined;
+
         yield* call(() =>
             navigator.locks.request(
                 lockNameForPath(action.newPath),
@@ -403,7 +405,7 @@ function* handleCopyFile(
                             throw new Error(`file '${action.newPath}' already exists`);
                         }
 
-                        await db.metadata.add((<Omit<FileMetadata, 'uuid'>>{
+                        uuid = await db.metadata.add((<Omit<FileMetadata, 'uuid'>>{
                             ...metadata,
                             uuid: undefined,
                             path: action.newPath,
@@ -424,7 +426,9 @@ function* handleCopyFile(
             ),
         );
 
-        yield* put(fileStorageDidCopyFile(action.path));
+        defined(uuid);
+
+        yield* put(fileStorageDidCopyFile(action.path, uuid));
     } catch (err) {
         yield* put(fileStorageDidFailToCopyFile(action.path, ensureError(err)));
     }


### PR DESCRIPTION
When duplicating a file users expect the file to be opened as in other applications.

Fixes: https://github.com/pybricks/support/issues/1084