### PR TITLE
Clarify why bluetooth may not be available

### DIFF
--- a/src/ble/alerts/translations/en.json
+++ b/src/ble/alerts/translations/en.json
@@ -6,9 +6,9 @@
         "action": "More Info"
     },
     "bluetoothNotAvailable": {
-        "message": "No Bluetooth adapter could be found.",
-        "suggestion": "Please connect or enable a Bluetooth Low Energy adapter and restart the browser.",
-        "browserSupport": "Some browsers like Brave and Opera do not support Web Bluetooth. Be sure to use a supported browser such as Chrome or Edge."
+        "message": "No Bluetooth adapter could be found or permission to use it has not been granted.",
+        "suggestion": "Please connect or enable a Bluetooth Low Energy adapter, ensure your browser has permission to use it and restart the browser.",
+        "browserSupport": "Some browsers like Brave and Opera do not support Web Bluetooth. Be sure to use a supported browser such as Chrome, Edge or on iOS WebBLE."
     },
     "noGatt": {
         "message": "The web browser did not give permission to use Bluetooth Low Energy."


### PR DESCRIPTION
On iOS `getAvailability()` returns false if the app does not have permission to use the bluetooth adapter (which is what the spec says it should do if permission has not been granted), so clarify the reason for it not being available.

Also add a sneaky reference to WebBLE as a supported browser on iOS.