### PR TITLE
vscode: fix breaking change in psioniq extension

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -39,6 +39,12 @@
     ],
     "psi-header.lang-config": [
         {
+            "language": "typescript",
+            "begin": "",
+            "end": "",
+            "prefix": "// "
+        },
+        {
             "language": "*",
             "begin": "",
             "end": "",


### PR DESCRIPTION
The extension now has a default typescript config an "*" doesn't override it so we have to have an explicit "typescript" entry.