### PR TITLE
revert overlay size hack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,6 @@
 
 ## [Unreleased]
 
-### Fixed
-- Fixed dialogs not displaying correctly on Android ([support#1271]).
-
-[support#1271]: https://github.com/pybricks/support/issues/1271
-
 ## [2.2.0-beta.9] - 2023-10-26
 
 ### Changed

--- a/src/index.scss
+++ b/src/index.scss
@@ -208,11 +208,6 @@ a.#{bp.$ns}-button {
     }
 }
 
-.#{bp.$ns}-overlay {
-    width: 100vw;
-    height: 100vh;
-}
-
 // don't take up so much space when there is no caret
 .#{bp.$ns}-tree-node-caret-none {
     // $pt-grid-size / 2 matches padding on .#{bp.$ns}-tree-node-conent


### PR DESCRIPTION
This broke other stuff by making the overlay present even when there was no content.