### PR TITLE
Keep the hub name as a default when installing/re-installing PyBricks Firmware 

### DIFF
--- a/src/ble/reducers.ts
+++ b/src/ble/reducers.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2020-2022 The Pybricks Authors
+// Copyright (c) 2020-2024 The Pybricks Authors
 //
 // Manages state for the Bluetooth Low Energy connection.
 // This assumes that there is only one global connection to a single device.
@@ -84,6 +84,14 @@ const deviceName: Reducer<string> = (state = '', action) => {
     return state;
 };
 
+const deviceNameLastConnected: Reducer<string> = (state = '', action) => {
+    if (bleDidConnectPybricks.matches(action)) {
+        return action.name;
+    }
+
+    return state;
+};
+
 const deviceType: Reducer<string> = (state = '', action) => {
     if (bleDidDisconnectPybricks.matches(action)) {
         return '';
@@ -136,6 +144,7 @@ export default combineReducers({
     connection,
     deviceName,
     deviceType,
+    deviceNameLastConnected,
     deviceFirmwareVersion,
     deviceLowBatteryWarning,
     deviceBatteryCharging,

--- a/src/firmware/installPybricksDialog/InstallPybricksDialog.tsx
+++ b/src/firmware/installPybricksDialog/InstallPybricksDialog.tsx
@@ -450,7 +450,7 @@ const BootloaderModePanel: React.FunctionComponent<BootloaderModePanelProps> = (
 
 export const InstallPybricksDialog: React.FunctionComponent = () => {
     const { isOpen } = useSelector((s) => s.firmware.installPybricksDialog);
-    const deviceName = useSelector((s) => s.ble.deviceName);
+    const deviceNameLastConnected = useSelector((s) => s.ble.deviceNameLastConnected);
     const inProgress = useSelector(
         (s) =>
             s.firmware.isFirmwareFlashUsbDfuInProgress ||
@@ -528,7 +528,7 @@ export const InstallPybricksDialog: React.FunctionComponent = () => {
                 title={i18n.translate('optionsPanel.title')}
                 panel={
                     <ConfigureOptionsPanel
-                        hubName={hubName || deviceName}
+                        hubName={hubName || deviceNameLastConnected}
                         metadata={
                             isCustomFirmwareRequested
                                 ? customFirmwareData?.metadata

--- a/src/firmware/installPybricksDialog/InstallPybricksDialog.tsx
+++ b/src/firmware/installPybricksDialog/InstallPybricksDialog.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2022-2023 The Pybricks Authors
+// Copyright (c) 2022-2024 The Pybricks Authors
 
 import './installPybricksDialog.scss';
 import {
@@ -450,6 +450,7 @@ const BootloaderModePanel: React.FunctionComponent<BootloaderModePanelProps> = (
 
 export const InstallPybricksDialog: React.FunctionComponent = () => {
     const { isOpen } = useSelector((s) => s.firmware.installPybricksDialog);
+    const deviceName = useSelector((s) => s.ble.deviceName);
     const inProgress = useSelector(
         (s) =>
             s.firmware.isFirmwareFlashUsbDfuInProgress ||
@@ -527,7 +528,7 @@ export const InstallPybricksDialog: React.FunctionComponent = () => {
                 title={i18n.translate('optionsPanel.title')}
                 panel={
                     <ConfigureOptionsPanel
-                        hubName={hubName}
+                        hubName={hubName || deviceName}
                         metadata={
                             isCustomFirmwareRequested
                                 ? customFirmwareData?.metadata


### PR DESCRIPTION
Initial implementation for keeping the last connected hub id in memory. [pybricks/support/#1415](https://github.com/pybricks/support/issues/1415)
Show it as the suggested name in the firmware dialog.

Next steps:
* keep the hub name and id (or even collect all connected hubs and names) in browser storage
* keep the hub name in hub's flash