### PR TITLE
Style side panel buttons and toggle terminal

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -4,7 +4,7 @@
 import 'react-splitter-layout/lib/index.css';
 import './app.scss';
 import { Button, Classes, Spinner } from '@blueprintjs/core';
-import { Manual } from '@blueprintjs/icons';
+import { Console, Manual } from '@blueprintjs/icons';
 import React, { useEffect, useState } from 'react';
 
 type SideView = 'off' | 'docs';
@@ -107,21 +107,44 @@ const App: React.FunctionComponent = () => {
         defaultDocsSplit,
     );
 
+    const resetDocsSplit = () => {
+        setDocsSplit(defaultDocsSplit);
+        resetSplitterSize(
+            '.splitter-layout.pb-show-docs, .splitter-layout.pb-hide-docs',
+            defaultDocsSplit,
+        );
+    };
+
     const docsOnClick = () => {
         if (sideView === 'docs' && docsSplit < 10) {
-            // Treat manually dragged closed like closed, so clicking will
-            // visually open it at default size.
-            setDocsSplit(defaultDocsSplit);
-            resetSplitterSize(
-                '.splitter-layout.pb-show-docs, .splitter-layout.pb-hide-docs',
-                defaultDocsSplit,
-            );
+            resetDocsSplit();
         } else {
             setSideView(sideView === 'docs' ? 'off' : 'docs');
         }
     };
 
-    const [terminalSplit, setTerminalSplit] = useLocalStorage('app-terminal-split', 30);
+    const defaultTerminalSplit = 30;
+    const [terminalSplit, setTerminalSplit] = useLocalStorage(
+        'app-terminal-split',
+        defaultTerminalSplit,
+    );
+    const [terminalVisible, setTerminalVisible] = useState(true);
+
+    const resetTerminalSplit = () => {
+        setTerminalSplit(defaultTerminalSplit);
+        resetSplitterSize(
+            '.splitter-layout.pb-show-terminal, .splitter-layout.pb-hide-terminal',
+            defaultTerminalSplit,
+        );
+    };
+
+    const terminalOnClick = () => {
+        if (terminalVisible && terminalSplit < 10) {
+            resetTerminalSplit();
+        } else {
+            setTerminalVisible(!terminalVisible);
+        }
+    };
 
     // Classes.DARK has to be applied to body element, otherwise it won't
     // affect portals
@@ -172,6 +195,11 @@ const App: React.FunctionComponent = () => {
                     >
                         <SplitterLayout
                             vertical={true}
+                            customClassName={
+                                terminalVisible
+                                    ? 'pb-show-terminal'
+                                    : 'pb-hide-terminal'
+                            }
                             percentage={true}
                             secondaryInitialSize={terminalSplit}
                             onSecondaryPaneSizeChange={setTerminalSplit}
@@ -187,6 +215,17 @@ const App: React.FunctionComponent = () => {
                                     <Editor />
                                 </React.Suspense>
                                 <div className="pb-app-side-view-buttons">
+                                    <Button
+                                        large
+                                        intent="primary"
+                                        icon={<Console />}
+                                        title={
+                                            terminalVisible
+                                                ? i18n.translate('terminal.hide')
+                                                : i18n.translate('terminal.show')
+                                        }
+                                        onClick={terminalOnClick}
+                                    />
                                     <Button
                                         large
                                         intent="primary"

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -70,13 +70,57 @@ const Docs: React.FunctionComponent = () => {
     );
 };
 
+/**
+ * HACK: react-splitter-layout is an uncontrolled component, so there is no
+ * clean way to reset its size programmatically.
+ */
+function resetSplitterSize(className: string, defaultSize: number): void {
+    const container = document.querySelector<HTMLElement>(className);
+
+    if (!container) {
+        return;
+    }
+
+    const fiberKey = Object.keys(container).find((k) => k.startsWith('__reactFiber'));
+    if (!fiberKey) {
+        return;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let fiber: any = (container as any)[fiberKey];
+    while (fiber && !fiber.stateNode?.handleMouseMove) {
+        fiber = fiber.return;
+    }
+
+    fiber?.stateNode?.setState({ secondaryPaneSize: defaultSize });
+}
+
 const App: React.FunctionComponent = () => {
     const i18n = useI18n();
     const { isDarkMode } = useTernaryDarkMode();
     const [sideView, setSideView] = useState<SideView>('off');
     const [isDragging, setIsDragging] = useState(false);
 
-    const [docsSplit, setDocsSplit] = useLocalStorage('app-docs-split', 30);
+    const defaultDocsSplit = 30;
+    const [docsSplit, setDocsSplit] = useLocalStorage(
+        'app-docs-split',
+        defaultDocsSplit,
+    );
+
+    const docsOnClick = () => {
+        if (sideView === 'docs' && docsSplit < 10) {
+            // Treat manually dragged closed like closed, so clicking will
+            // visually open it at default size.
+            setDocsSplit(defaultDocsSplit);
+            resetSplitterSize(
+                '.splitter-layout.pb-show-docs, .splitter-layout.pb-hide-docs',
+                defaultDocsSplit,
+            );
+        } else {
+            setSideView(sideView === 'docs' ? 'off' : 'docs');
+        }
+    };
+
     const [terminalSplit, setTerminalSplit] = useLocalStorage('app-terminal-split', 30);
 
     // Classes.DARK has to be applied to body element, otherwise it won't
@@ -152,11 +196,7 @@ const App: React.FunctionComponent = () => {
                                                 ? i18n.translate('docs.hide')
                                                 : i18n.translate('docs.show')
                                         }
-                                        onClick={() =>
-                                            setSideView(
-                                                sideView === 'docs' ? 'off' : 'docs',
-                                            )
-                                        }
+                                        onClick={docsOnClick}
                                     />
                                 </div>
                             </main>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -142,22 +142,23 @@ const App: React.FunctionComponent = () => {
                                 >
                                     <Editor />
                                 </React.Suspense>
-                                <Button
-                                    className="pb-app-doc-button"
-                                    minimal
-                                    large
-                                    icon={<Manual />}
-                                    title={
-                                        sideView === 'docs'
-                                            ? i18n.translate('docs.hide')
-                                            : i18n.translate('docs.show')
-                                    }
-                                    onClick={() =>
-                                        setSideView(
-                                            sideView === 'docs' ? 'off' : 'docs',
-                                        )
-                                    }
-                                />
+                                <div className="pb-app-side-view-buttons">
+                                    <Button
+                                        large
+                                        intent="primary"
+                                        icon={<Manual />}
+                                        title={
+                                            sideView === 'docs'
+                                                ? i18n.translate('docs.hide')
+                                                : i18n.translate('docs.show')
+                                        }
+                                        onClick={() =>
+                                            setSideView(
+                                                sideView === 'docs' ? 'off' : 'docs',
+                                            )
+                                        }
+                                    />
+                                </div>
                             </main>
                             <aside
                                 className="pb-app-terminal"

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -211,3 +211,14 @@ div.pb-hide-docs > :not(.layout-pane-primary) {
     width: 0 !important;
     min-width: 0 !important;
 }
+
+// hide the terminal and resize separator
+// Same approach as docs: keep the terminal in the DOM to preserve its content,
+// but collapse the secondary pane to zero height.
+div.pb-hide-terminal > :not(.layout-pane-primary) {
+    visibility: hidden;
+    pointer-events: none;
+    flex-basis: 0 !important;
+    height: 0 !important;
+    min-height: 0 !important;
+}

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -79,11 +79,19 @@
     }
 }
 
-.pb-app-doc-button {
+.pb-app-side-view-buttons {
     position: absolute;
     bottom: bp.$pt-grid-size;
     right: bp.$pt-grid-size;
     z-index: bp.$pt-z-index-overlay;
+    display: flex;
+    flex-direction: row;
+    gap: bp.$pt-grid-size * 0.5;
+
+    // match toolbar button appearance: no box-shadow border or active-state shadow
+    & * {
+        box-shadow: unset !important;
+    }
 }
 
 $splitter-background-color: bp.$light-gray2;

--- a/src/app/translations/en.json
+++ b/src/app/translations/en.json
@@ -8,5 +8,9 @@
     "docs": {
         "show": "Show documentation",
         "hide": "Hide documentation"
+    },
+    "terminal": {
+        "show": "Show terminal",
+        "hide": "Hide terminal"
     }
 }


### PR DESCRIPTION
- Styles the doc button as blue
- Adds a terminal toggle button
- Adds a close all button

--------
reason 1: Generalize side panel

We'd like to use this for more than just docs, such as a camera view or telemetry.

--------
reason 2: 

This fixes some usability issues for beginning users:
- When dragging the terminal or docs to nearly closed, it could be hard to know where they went. Clicking the docs button would not make it re-appear. The buttons will now restore them to default size.
- The docs button was harder to discover since it looked like an character in the editor. Now it looks like the other buttons.

https://github.com/user-attachments/assets/6c4a0394-e3cc-49ec-a429-cae52fc35ae6

