### PR TITLE
Simplify testing: optionally use https, drop verbose USB debug.

### DIFF
--- a/scripts/serve.py
+++ b/scripts/serve.py
@@ -6,9 +6,11 @@ Serve the build directory using builtin Python web server.
 
 import http.server
 import pathlib
-import socketserver
+import ssl
 
 BUILD_DIR = (pathlib.Path(__file__).parent.parent / "build").resolve()
+CERT_FILE = BUILD_DIR / "cert.pem"
+KEY_FILE = BUILD_DIR / "key.pem"
 PORT = 8000
 
 
@@ -17,10 +19,10 @@ class Handler(http.server.SimpleHTTPRequestHandler):
         self,
         request: bytes,
         client_address: tuple[str, int],
-        server: socketserver.BaseServer,
+        server: http.server.HTTPServer,
         directory: str | None = ...
     ) -> None:
-        super().__init__(request, client_address, server, directory=BUILD_DIR)
+        super().__init__(request, client_address, server, directory=str(BUILD_DIR))
 
     def end_headers(self) -> None:
         # custom headers needed for some web API features
@@ -29,6 +31,14 @@ class Handler(http.server.SimpleHTTPRequestHandler):
         return super().end_headers()
 
 
-with socketserver.TCPServer(("", PORT), Handler) as httpd:
-    print(f"serving at http://0.0.0.0:{PORT}")
-    httpd.serve_forever()
+httpd = http.server.HTTPServer(("", PORT), Handler)
+
+if CERT_FILE.exists() and KEY_FILE.exists():
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    ctx.load_cert_chain(certfile=CERT_FILE, keyfile=KEY_FILE)
+    httpd.socket = ctx.wrap_socket(httpd.socket, server_side=True)
+    print(f"serving at https://0.0.0.0:{PORT}")
+else:
+    print(f"cert/key not found, serving without TLS at http://0.0.0.0:{PORT}")
+
+httpd.serve_forever()

--- a/src/usb/sagas.ts
+++ b/src/usb/sagas.ts
@@ -461,8 +461,6 @@ function* handleUsbConnectPybricks(hotPlugDevice?: USBDevice): Generator {
                 continue;
             }
 
-            console.debug('Received USB message:', result.data);
-
             switch (result.data.getInt8(0)) {
                 case PybricksUsbInEndpointMessageType.Response:
                     yield* put(
@@ -508,8 +506,6 @@ function* handleUsbConnectPybricks(hotPlugDevice?: USBDevice): Generator {
 
         for (;;) {
             const action = yield* take(chan);
-
-            console.debug('Processing USB action:', action);
 
             if (usbPybricksSubscribe.matches(action)) {
                 const message = new DataView(new ArrayBuffer(2));


### PR DESCRIPTION
Serving with https allows local testing with a phone.

The USB debug was hiding most other things.